### PR TITLE
Add support for Rust

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -125,7 +125,7 @@ case "$1" in
     echo "/* ${TODO_COMMENT} */"
     ;;
 
-  *.cc | *.cpp | *.go | *.hpp | *.java | *.js | *.proto | *.scala)
+  *.cc | *.cpp | *.go | *.hpp | *.java | *.js | *.proto | *.scala | *.rs)
     printLicenseNonHashComment "//"
     printFileCommentTemplate "//"
     ;;


### PR DESCRIPTION
Rust has the same comment syntax as C++, so add .rs extension to that case.