### PR TITLE
Resolve symlinks when determining the src directory.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -23,7 +23,7 @@
 #   autogen.sh file.js
 #   autogen.sh file.py
 
-declare -r SRCDIR="${TEST_SRCDIR:-$(dirname $0)}"
+declare -r SRCDIR="${TEST_SRCDIR:-$(dirname $(realpath $0))}"
 
 LICENSE="${SRCDIR}/licenses/apache-2.0.txt"
 COPYRIGHT_HOLDER="Google Inc."


### PR DESCRIPTION
For example I had autogen.sh symlink'd from a bin directory:

    $ ls -l ~/bin/
    autogen.sh@ -> ../vendor/autogen/autogen.sh

When running `autogen.sh` it assumed the licences are in `~/bin`. After this
change, it correctly finds the licences in `vendor/autogen/`.