### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,9 @@
 os:
   - linux
   - osx
+addons:
+  apt:
+    packages:
+      - bc
+      - ed
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,6 @@ addons:
       - bc
       - ed
 script: make test
+env:
+  global:
+    - VERBOSE=2

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/mbrukman/autogen.svg?branch=master)](https://travis-ci.org/mbrukman/autogen)
+
 autogen
 =======
 

--- a/tests/data_tests.sh
+++ b/tests/data_tests.sh
@@ -83,12 +83,18 @@ function run_one_test() {
 
   if [ ${stdout} -eq 0 ]; then
     echo "  Differences in stdout; compare via: diff -u ${expected_out} ${actual_out}"
+    if [ "${VERBOSE}" -ge 2 ]; then
+      diff -u "${expected_out}" "${actual_out}"
+    fi
   else
     rm -f "${actual_out}"
   fi
 
   if [ ${stderr} -eq 0 ]; then
     echo "  Differences in stderr; compare via: diff -u ${expected_err} ${actual_err}"
+    if [ "${VERBOSE}" -ge 2 ]; then
+      diff -u "${expected_err}" "${actual_err}"
+    fi
   else
     rm -f "${actual_err}"
   fi

--- a/tests/data_tests.sh
+++ b/tests/data_tests.sh
@@ -44,8 +44,8 @@ function run_one_test() {
   local expected_err="$3"
 
   local filebase="$(basename "${input%.in}")"
-  local actual_out="$(mktemp "/${TMPDIR}/${filebase}.out.XXXXXX")"
-  local actual_err="$(mktemp "/${TMPDIR}/${filebase}.err.XXXXXX")"
+  local actual_out="$(mktemp "${TMPDIR}/${filebase}.out.XXXXXX")"
+  local actual_err="$(mktemp "${TMPDIR}/${filebase}.err.XXXXXX")"
 
   # Run tests in a hermetic environment such that they don't break every year.
   bash -c "${SRCDIR}/autogen.sh -y 2014 $(cat "${input}")" > "${actual_out}" 2> "${actual_err}"


### PR DESCRIPTION
The inaugural [Travis build](https://travis-ci.org/mbrukman/autogen/jobs/160776912) appears to be failing in a peculiar way on Linux, with 12 of 53 tests passing from `data_tests.sh` suite whereas all of the tests [pass on OS X](https://travis-ci.org/mbrukman/autogen/jobs/160776913).

The goal of this PR is to iteratively figure out what needs to be changed in order to make the tests pass on Travis, since they already pass locally on both Linux and OS X.

In theory, each push to this branch should cause a new Travis test run to allow us to figure out the issue and fix it.