### PR TITLE
Use the new test utility library everywhere.

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -14,6 +14,14 @@
 #
 ################################################################################
 
+sh_library(
+    name = "test_util",
+    srcs = [
+        "test_util.sh",
+    ],
+    testonly = 1
+)
+
 sh_test(
     name = "data_tests",
     srcs = ["data_tests.sh"],
@@ -21,6 +29,7 @@ sh_test(
         "//:autogen",
         "//licenses",
         "//testdata",
+        ":test_util",
     ],
     size = "small",
     timeout = "short",
@@ -31,6 +40,7 @@ sh_test(
     srcs = ["inplace_tests.sh"],
     data = [
         "//:autogen",
+        ":test_util",
     ],
     size = "small",
     timeout = "short",
@@ -41,6 +51,7 @@ sh_test(
     srcs = ["inplace_perm_tests.sh"],
     data = [
         "//:autogen",
+        ":test_util",
     ],
     size = "small",
     timeout = "short",
@@ -51,6 +62,7 @@ sh_test(
     srcs = ["symlink_tests.sh"],
     data = [
         "//:autogen",
+        ":test_util",
     ],
     size = "small",
     timeout = "short",

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -27,8 +27,8 @@ for file in *_tests.sh; do
   fi
   echo "Running tests in ${file} ..."
   bash "${file}" \
-      && test_print_passed "${file}" \
-      || test_print_failed "${file}"
+      && test_record_and_print_passed "${file}" \
+      || test_record_and_print_failed "${file}"
   echo
 done
 

--- a/tests/symlink_tests.sh
+++ b/tests/symlink_tests.sh
@@ -18,6 +18,8 @@
 
 set -eu
 
+source "$(dirname $0)/test_util.sh"
+
 # If we're runnig via Bazel, find the source files via $TEST_SRCDIR;
 # otherwise, default to dir of current file and search relative to that.
 #
@@ -53,8 +55,6 @@ ln -s "${AUTOGEN_FULL_PATH}"   "${AUTOGEN_SYMLINKS[0]}"
 ln -s "${AUTOGEN_SYMLINKS[0]}" "${AUTOGEN_SYMLINKS[1]}"
 ln -s "${AUTOGEN_SYMLINKS[1]}" "${AUTOGEN_SYMLINKS[2]}"
 
-declare -i status_code=0
-
 for ext in hs ml pl rb py sh; do
   expected_file="${TMPDIR}/expected.${ext}"
   touch "${expected_file}"
@@ -64,26 +64,11 @@ for ext in hs ml pl rb py sh; do
     actual_file="${TMPDIR}/$(basename $autogen).actual.${ext}"
     touch "${actual_file}"
     "${autogen}" -i "${actual_file}"
-    if ! diff -u "${expected_file}" "${actual_file}" ; then
-      status_code=1
-    fi
+    diff -u "${expected_file}" "${actual_file}" \
+        && test_record_passed \
+        || test_record_failed
   done
 done
 
-if [[ ${status_code} -eq 0 ]]; then
-  if [ -t 1 ]; then
-    declare -r PASSED="\033[0;32mPASSED\033[0m"
-  else
-    declare -r PASSED="PASSED"
-  fi
-  echo -e "${PASSED}"
-else
-  if [ -t 1 ]; then
-    declare -r FAILED="\033[0;31mFAILED\033[0m"
-  else
-    declare -r FAILED="FAILED"
-  fi
-  echo -e "${FAILED}"
-fi
-
-exit ${status_code}
+test_print_status
+test_exit

--- a/tests/test_util.sh
+++ b/tests/test_util.sh
@@ -47,12 +47,12 @@ function test_reset() {
 }
 
 # Record test as having passed.
-function test_silent_passed() {
+function test_record_passed() {
   (( num_passed_tests += 1 ))
   (( num_total_tests += 1 ))
 }
 
-# Record test as having passed and print a status message.
+# Print a status message for a passed test.
 #
 # Args:
 #   $1: (optional) additional status to print out
@@ -61,19 +61,26 @@ function test_print_passed() {
   if [ -n "${status_msg}" ]; then
     status_msg=": ${status_msg}"
   fi
-
-  test_silent_passed
   echo -e "${PASSED}${status_msg}"
 }
 
+# Record a test having passed and print a status message.
+#
+# Args:
+#   $1: (optional) additional status to print out
+function test_record_and_print_passed() {
+  test_record_passed
+  test_print_passed "${1:-}"
+}
+
 # Record test as having failed.
-function test_silent_failed() {
+function test_record_failed() {
   (( num_failed_tests += 1 ))
   (( num_total_tests += 1 ))
   (( status_code = 1 ))
 }
 
-# Record test as having failed and print a status message.
+# Print a status message for a failed test.
 #
 # Args:
 #   $1: (optional) additional status to print out
@@ -82,9 +89,16 @@ function test_print_failed() {
   if [ -n "${status_msg}" ]; then
     status_msg=": ${status_msg}"
   fi
-
-  test_silent_failed
   echo -e "${FAILED}${status_msg}"
+}
+
+# Record a test having failed and print a status message.
+#
+# Args:
+#   $1: (optional) additional status to print out
+function test_record_and_print_failed() {
+  test_record_failed
+  test_print_failed "${1:-}"
 }
 
 # Print overall status, including the counters.


### PR DESCRIPTION
Updated all tests to use the new `test_util.sh` library, eliminating a bunch of
repeated boilerplate code in various scripts.

Split the test status recording from printing to allow using them separately,
depending on the requirements for a particular test.