### PR TITLE
Switch to `sudo: true` to fix Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,11 @@
 ################################################################################
 
 language: generic
-sudo: false
+
+# `sudo` is required only because `ed` is not yet a whitelisted package:
+# https://github.com/travis-ci/apt-package-whitelist/issues/3681
+# Once it is, we can drop this and switch to container-based builds.
+sudo: true
 
 addons:
   apt:


### PR DESCRIPTION
Because `ed` is not yet a whitelisted package, container-based tests fail on
Travis because that package cannot be installed without root privileges.

This temporary change enables us to get a working Travis build/test cycle until
this is fixed: https://github.com/travis-ci/apt-package-whitelist/issues/3681