### PR TITLE
Install Bazel via APT config in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,14 +71,13 @@ matrix:
 
       addons:
         apt:
+          sources:
+            - sourceline: "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8"
+              key_url: "https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg"
           packages:
             - oracle-java8-installer
+            - bazel
 
-      before_script:
-        - echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-        - curl "https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg" | sudo apt-key add -
-        - sudo apt-get update
-        - sudo apt-get install -qq -y bazel
       script:
         - bazel test //...
     - os: osx


### PR DESCRIPTION
The declarative YAML method of specifying sources and keys is shorter and easier
to understand than the manual shell commands to accomplish the same goal.