### PR TITLE
Drop `sudo` for macOS X.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,10 +84,12 @@ matrix:
 
     - os: osx
       env: TEST_RUNNER=make VERBOSE=2
+      sudo: false
       script: make test
 
     - os: osx
       env: TEST_RUNNER=bazel
+      sudo: false
       before_install:
         - brew update
         - brew install bazel


### PR DESCRIPTION
Since we don't issue any `sudo` commands, we can drop the `sudo` requirement
from both macOS X jobs.