### PR TITLE
Remove the need for `bc` by calculating with Perl.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ matrix:
       addons:
         apt:
           packages:
-            - bc
             - ed
 
       script: make test
@@ -88,7 +87,6 @@ matrix:
             - sourceline: "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8"
               key_url: "https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg"
           packages:
-            - bc
             - ed
             - oracle-java8-installer
             - bazel

--- a/autogen
+++ b/autogen
@@ -114,7 +114,7 @@ function printFileCommentTemplate() {
       ;;
     *)
       # Fit into 80 cols: repeat enough times, depending on our comment width.
-      local repeat=$(echo 80 / $(echo -n "${comment}" | wc -c) | bc)
+      local repeat=$(perl -e "use POSIX; print floor(80 / length('${comment}'));")
       echo $comment
       perl -e "print \"$comment\" x $repeat . \"\n\""
       echo $comment


### PR DESCRIPTION
We are already using `perl` to print out the comment sequence repeatedly, so we
can make use of it as a calculator as well and remove the need for installing
another binary, namely `bc`.