### PR TITLE
Clean up in-place file editing to prepend license.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,41 +27,9 @@ matrix:
 
     - os: linux
       dist: trusty
-      env: TEST_RUNNER=make VERBOSE=2 EDITOR=ex
-
-      sudo: false
-
-      addons:
-        apt:
-          packages:
-            - vim  # provides `ex`; whitelisted package
-
-      script: make test
-
-    - os: linux
-      dist: trusty
-      env: TEST_RUNNER=make VERBOSE=2 EDITOR=ed
-
-      # `sudo` is required only because `ed` is not yet a whitelisted package:
-      # https://github.com/travis-ci/apt-package-whitelist/issues/3681
-      # Once it is, we can drop this and switch to container-based builds.
-      sudo: true
-
-      addons:
-        apt:
-          packages:
-            - ed
-
-      script: make test
-
-    - os: linux
-      dist: trusty
       env: TEST_RUNNER=bazel
 
       # `sudo` is required because:
-      #
-      # * `ed` is not yet a whitelisted package:
-      #   https://github.com/travis-ci/apt-package-whitelist/issues/3681
       #
       # * Bazel source repo is not whitelisted:
       #   https://github.com/travis-ci/apt-source-whitelist/issues/305

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,25 @@ matrix:
     - os: linux
       dist: trusty
       env: TEST_RUNNER=make VERBOSE=2
+      sudo: false
+      script: make test
+
+    - os: linux
+      dist: trusty
+      env: TEST_RUNNER=make VERBOSE=2 EDITOR=ex
+
+      sudo: false
+
+      addons:
+        apt:
+          packages:
+            - vim  # provides `ex`; whitelisted package
+
+      script: make test
+
+    - os: linux
+      dist: trusty
+      env: TEST_RUNNER=make VERBOSE=2 EDITOR=ed
 
       # `sudo` is required only because `ed` is not yet a whitelisted package:
       # https://github.com/travis-ci/apt-package-whitelist/issues/3681
@@ -87,7 +106,6 @@ matrix:
             - sourceline: "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8"
               key_url: "https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg"
           packages:
-            - ed
             - oracle-java8-installer
             - bazel
 

--- a/autogen
+++ b/autogen
@@ -94,13 +94,26 @@ function printLicenseHashComment() {
 function prependToFileInPlace() {
   local -r file="${1}"
 
-  # Prepend stdin to the beginning of the file using `ed`.
-  cat | ed -s "${file}" << EOF
-0a
-$(cat -)
-.
+  # Prepend stdin to the beginning of the file.
+  local -r header="$(mktemp /tmp/autogen-inplace.header.XXXXXX)"
+  trap "rm -f ${header}" EXIT
+  cat > "${header}"
+
+  if which ed > /dev/null 2>&1; then
+    ed -s "${file}" << EOF
+0r !cat ${header}
 w
+q
 EOF
+  elif which ex > /dev/null 2>&1; then
+    ex -sc "0r !cat ${header}" -cx $1
+  else
+    local -r staging="$(mktemp /tmp/autogen-inplace.staging.XXXXXX)"
+    trap "rm -f ${staging}" EXIT
+
+    cat "${header}" "${file}" > "${staging}"
+    cat "${staging}" > "${file}"
+  fi
 }
 
 SEPARATE_LICENSE_FROM_TODO="blank"

--- a/autogen
+++ b/autogen
@@ -94,26 +94,17 @@ function printLicenseHashComment() {
 function prependToFileInPlace() {
   local -r file="${1}"
 
-  # Prepend stdin to the beginning of the file.
-  local -r header="$(mktemp /tmp/autogen-inplace.header.XXXXXX)"
-  trap "rm -f ${header}" EXIT
-  cat > "${header}"
+  local -r staging="$(mktemp /tmp/autogen-inplace.staging.XXXXXX)"
+  # In case we exit due to an error early, clean up.
+  # We also clean up explicitly below.
+  trap "rm -f ${staging}" EXIT
 
-  if which ed > /dev/null 2>&1; then
-    ed -s "${file}" << EOF
-0r !cat ${header}
-w
-q
-EOF
-  elif which ex > /dev/null 2>&1; then
-    ex -sc "0r !cat ${header}" -cx $1
-  else
-    local -r staging="$(mktemp /tmp/autogen-inplace.staging.XXXXXX)"
-    trap "rm -f ${staging}" EXIT
+  cat - "${file}" > "${staging}"
+  cat "${staging}" > "${file}"
 
-    cat "${header}" "${file}" > "${staging}"
-    cat "${staging}" > "${file}"
-  fi
+  # Future calls to `trap` overwrite previous ones, so make sure to delete our
+  # temporary file.
+  rm -f "${staging}"
 }
 
 SEPARATE_LICENSE_FROM_TODO="blank"


### PR DESCRIPTION
Fix `ed` method to not source in input (as that will also run commands);
instead, read from a temporary file.

Add an alternative using `ex`, which is really `vim`, and which is a whitelisted
package, which does not require `sudo` to install.

Finally, bring back the original approach of using temporary files, but instead
of using `mv`, use `cat` as it will preserve file ownership, group, and
permissions.

Also updated Travis config to run all tests with each of these methods.