### PR TITLE
Use Bazel macro to simplify BUILD file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 
-[BUILD,*.py]
+[BUILD,*.bzl,*.py]
 indent_size = 4
 
 [Makefile]

--- a/tests/autogen_test.bzl
+++ b/tests/autogen_test.bzl
@@ -12,32 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(":autogen_test.bzl", "autogen_test")
-
-sh_library(
-    name = "test_util",
-    srcs = [
-        "test_util.sh",
-    ],
-    testonly = 1,
-)
-
-autogen_test(
-    name = "data",
-    data = [
-        "//licenses",
-        "//testdata",
-    ],
-)
-
-autogen_test(
-    name = "inplace",
-)
-
-autogen_test(
-    name = "inplace_perm",
-)
-
-autogen_test(
-    name = "symlink",
-)
+def autogen_test(name=None, srcs=[], data=[]):
+    native.sh_test(
+        name = name,
+        srcs = ["%s_test.sh" % name] + srcs,
+        data = [
+            "//:autogen_tool",
+            ":test_util",
+        ] + data,
+        size = "small",
+        timeout = "short",
+    )


### PR DESCRIPTION
Eliminates repetitive copy-pasted boilerplate for tests.