### PR TITLE
Update `make regen` to work with new directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ matrix:
       dist: trusty
       env: TEST_RUNNER=make VERBOSE=2
       sudo: false
-      script: make test
+      script:
+        - make test
+        - make regen-test
 
     - os: linux
       dist: trusty
@@ -83,7 +85,9 @@ matrix:
     - os: osx
       env: TEST_RUNNER=make VERBOSE=2
       sudo: false
-      script: make test
+      script:
+        - make test
+        - make regen-test
 
     - os: osx
       env: TEST_RUNNER=bazel

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,7 @@ test:
 
 regen:
 	$(VERB) bash gen_test_results.sh
+
+regen-test:
+	$(VERB) $(MAKE) regen
+	$(VERB) $(MAKE) test

--- a/gen_test_results.sh
+++ b/gen_test_results.sh
@@ -23,7 +23,7 @@
 function gen_test_data() {
   local files="$@"
   if [[ -z "${files}" ]]; then
-    files=testdata/*.in
+    files=tests/testdata/*.in
   fi
 
   for input in ${files}; do


### PR DESCRIPTION
Also add test to make sure that `make regen` continues to work.

This fixes the `make regen` target after PR #33 moved the `testdata` directory to `tests/testdata`.