### PR TITLE
Remove subprocessing for inline modification

### DIFF
--- a/autogen
+++ b/autogen
@@ -269,116 +269,109 @@ fi
 
 declare -r FILE="$1"
 
-# Re-run this script with all the same flags, minus the in-place flag.
-if [[ "${MODIFY_FILE_INPLACE}" -eq 1 ]]; then
-  $0 \
-    -c "${COPYRIGHT_HOLDER}" \
-    -l "${LICENSE_NAME}" \
-    -y "${YEAR}" \
-    "${FILE}" \
-    | prependToFileInPlace "${FILE}"
-  exit $?
-fi
+# Args:
+#   $1: filename
+function autogenForFile() {
+  local file="$1"
+  case "${file}" in
 
-case "${FILE}" in
+    # TODO(mbrukman): in some projects, *.h are actually C++ files where users
+    # want to use C++ style "//" comments. How can we handle this flexibility?
+    *.c | *.h | *.css)
+      echo "/*"
+      printLicenseNonHashComment " *"
+      echo " */"
+      echo
+      echo "/* ${TODO_COMMENT} */"
+      ;;
 
-  # TODO(mbrukman): in some projects, *.h are actually C++ files where users
-  # want to use C++ style "//" comments. How can we handle this flexibility?
-  *.c | *.h | *.css)
-    echo "/*"
-    printLicenseNonHashComment " *"
-    echo " */"
-    echo
-    echo "/* ${TODO_COMMENT} */"
-    ;;
+    *.cc | *.cpp | *.cs | *.go | *.hh | *.hpp | *.java | *.js | *.m | *.mm | *.proto | *.rs | *.scala | *.swift)
+      printLicenseNonHashComment "//"
+      printFileCommentTemplate "//"
+      ;;
 
-  *.cc | *.cpp | *.cs | *.go | *.hh | *.hpp | *.java | *.js | *.m | *.mm | *.proto | *.rs | *.scala | *.swift)
-    printLicenseNonHashComment "//"
-    printFileCommentTemplate "//"
-    ;;
+    *.el | .emacs | *.lisp)
+      printLicenseNonHashComment ";;"
+      printFileCommentTemplate ";;"
+      ;;
 
-  *.el | .emacs | *.lisp)
-    printLicenseNonHashComment ";;"
-    printFileCommentTemplate ";;"
-    ;;
+    *.erl)
+      printLicenseNonHashComment "%"
+      printFileCommentTemplate "%"
+      ;;
 
-  *.erl)
-    printLicenseNonHashComment "%"
-    printFileCommentTemplate "%"
-    ;;
+    *.hs)
+      printLicenseNonHashComment "--"
+      printFileCommentTemplate "--"
+      ;;
 
-  *.hs)
-    printLicenseNonHashComment "--"
-    printFileCommentTemplate "--"
-    ;;
+    *.html | *.xml)
+      echo "<!--"
+      printLicenseNonHashComment " "
+      echo "-->"
+      ;;
 
-  *.html | *.xml)
-    echo "<!--"
-    printLicenseNonHashComment " "
-    echo "-->"
-    ;;
+    *.jsonnet)
+      printLicenseHashComment
+      printFileCommentTemplate "#"
+      ;;
 
-  *.jsonnet)
-    printLicenseHashComment
-    printFileCommentTemplate "#"
-    ;;
+    *.md | *.markdown)
+      printLicenseWithYear
+      ;;
 
-  *.md | *.markdown)
-    printLicenseWithYear
-    ;;
+    *.ml | *.sml)
+      echo "(*"
+      printLicenseNonHashComment " *"
+      echo " *)"
+      echo
+      echo "(* ${TODO_COMMENT} *)"
+      ;;
 
-  *.ml | *.sml)
-    echo "(*"
-    printLicenseNonHashComment " *"
-    echo " *)"
-    echo
-    echo "(* ${TODO_COMMENT} *)"
-    ;;
+    *.php)
+      # We can't make PHP scripts locally executable with the #!/usr/bin/php line
+      # because PHP comments only have meaning inside the <?php ... ?> which
+      # means the first line cannot be simply #!/usr/bin/php to let the shell
+      # know how to run these scripts.  Instead, we'll have to run them via
+      # "php script.php" .
+      #
+      # Note: PHP accepts C, C++, and shell-style comments.
+      echo "<?php"
+      printLicenseNonHashComment "//"
+      printFileCommentTemplate "//"
+      echo
+      # E_STRICT was added in PHP 5.0 and became included in E_ALL in PHP 6.0 .
+      echo "error_reporting(E_ALL | E_STRICT);"
+      echo "?>"
+      ;;
 
-  *.php)
-    # We can't make PHP scripts locally executable with the #!/usr/bin/php line
-    # because PHP comments only have meaning inside the <?php ... ?> which
-    # means the first line cannot be simply #!/usr/bin/php to let the shell
-    # know how to run these scripts.  Instead, we'll have to run them via
-    # "php script.php" .
-    #
-    # Note: PHP accepts C, C++, and shell-style comments.
-    echo "<?php"
-    printLicenseNonHashComment "//"
-    printFileCommentTemplate "//"
-    echo
-    # E_STRICT was added in PHP 5.0 and became included in E_ALL in PHP 6.0 .
-    echo "error_reporting(E_ALL | E_STRICT);"
-    echo "?>"
-    ;;
+    *.pl)
+      echo "#!/usr/bin/perl"
+      echo "#"
+      printLicenseHashComment
+      printFileCommentTemplate "#"
+      echo
+      echo "use strict;"
+      ;;
 
-  *.pl)
-    echo "#!/usr/bin/perl"
-    echo "#"
-    printLicenseHashComment
-    printFileCommentTemplate "#"
-    echo
-    echo "use strict;"
-    ;;
-
-  test_*.py | *_test.py)
-    echo "#!/usr/bin/python"
-    echo "#"
-    printLicenseHashComment
-    cat <<EOF
+    test_*.py | *_test.py)
+      echo "#!/usr/bin/python"
+      echo "#"
+      printLicenseHashComment
+      cat <<EOF
 
 """${TODO_COMMENT}"""
 EOF
-    BASE_PY="${1/#test_/}"
-    BASE_PY="${BASE_PY/_test/}"
-    echo
-    echo "import unittest"
-    # Maybe import the package that this is intended to test.
-    if [ -e "${BASE_PY}" ]; then
-      echo "import ${BASE_PY/%.py/}"
-    fi
-    # Add basic bootstrap code.
-    cat <<EOF
+      BASE_PY="${1/#test_/}"
+      BASE_PY="${BASE_PY/_test/}"
+      echo
+      echo "import unittest"
+      # Maybe import the package that this is intended to test.
+      if [ -e "${BASE_PY}" ]; then
+        echo "import ${BASE_PY/%.py/}"
+      fi
+      # Add basic bootstrap code.
+      cat <<EOF
 
 
 class FooTest(unittest.TestCase):
@@ -396,13 +389,13 @@ class FooTest(unittest.TestCase):
 if __name__ == '__main__':
     unittest.main()
 EOF
-    ;;
+      ;;
 
-  *.py)
-    echo "#!/usr/bin/python"
-    echo "#"
-    printLicenseHashComment
-    cat <<EOF
+    *.py)
+      echo "#!/usr/bin/python"
+      echo "#"
+      printLicenseHashComment
+      cat <<EOF
 
 """${TODO_COMMENT}"""
 
@@ -416,62 +409,70 @@ def main(argv):
 if __name__ == '__main__':
     main(sys.argv)
 EOF
-    ;;
+      ;;
 
-  *.rb)
-    echo "#!/usr/bin/ruby"
-    echo "#"
-    printLicenseHashComment
-    printFileCommentTemplate "#"
-    ;;
+    *.rb)
+      echo "#!/usr/bin/ruby"
+      echo "#"
+      printLicenseHashComment
+      printFileCommentTemplate "#"
+      ;;
 
-  *.sh)
-    echo "#!/bin/bash -eu"
-    echo "#"
-    printLicenseHashComment
-    printFileCommentTemplate "#"
-    ;;
+    *.sh)
+      echo "#!/bin/bash -eu"
+      echo "#"
+      printLicenseHashComment
+      printFileCommentTemplate "#"
+      ;;
 
-  *.tcl)
-    echo "#!/usr/bin/tclsh"
-    echo "#"
-    printLicenseHashComment
-    printFileCommentTemplate "#"
-    ;;
+    *.tcl)
+      echo "#!/usr/bin/tclsh"
+      echo "#"
+      printLicenseHashComment
+      printFileCommentTemplate "#"
+      ;;
 
-  *.txt | README)
-    printLicenseWithYear
-    ;;
+    *.txt | README)
+      printLicenseWithYear
+      ;;
 
-  *.vim | .vimrc | vimrc)
-    printLicenseNonHashComment \"
-    if [[ "${SEPARATE_LICENSE_FROM_TODO}" == "blank" ]]; then
-      echo
-    else
-      # Handle the file header locally; hard to pass a double-quote to function
-      # which wants to double-quote its arguments.
-      echo "\""
-      perl -e "print '\"' x 80 . \"\n\""
-      echo "\""
-    fi
-    echo "\" ${TODO_COMMENT}"
-    ;;
+    *.vim | .vimrc | vimrc)
+      printLicenseNonHashComment \"
+      if [[ "${SEPARATE_LICENSE_FROM_TODO}" == "blank" ]]; then
+        echo
+      else
+        # Handle the file header locally; hard to pass a double-quote to function
+        # which wants to double-quote its arguments.
+        echo "\""
+        perl -e "print '\"' x 80 . \"\n\""
+        echo "\""
+      fi
+      echo "\" ${TODO_COMMENT}"
+      ;;
 
-  *.yaml | *.yml)
-    printLicenseHashComment
-    printFileCommentTemplate "#"
-    ;;
+    *.yaml | *.yml)
+      printLicenseHashComment
+      printFileCommentTemplate "#"
+      ;;
 
-  BUILD | Dockerfile | Makefile | Makefile.* | Rakefile | Vagrantfile)
-    printLicenseHashComment
-    printFileCommentTemplate "#"
-    ;;
+    BUILD | Dockerfile | Makefile | Makefile.* | Rakefile | Vagrantfile)
+      printLicenseHashComment
+      printFileCommentTemplate "#"
+      ;;
 
-  *)
-    if [ ${SILENT} -eq 0 ] ; then
-      echo "File type not recognized: ${FILE}" >&2
-      exit 1
-    fi
-    ;;
+    *)
+      if [ ${SILENT} -eq 0 ] ; then
+        echo "File type not recognized: ${file}" >&2
+        exit 1
+      fi
+      ;;
 
-esac
+  esac
+}
+
+if [[ "${MODIFY_FILE_INPLACE}" -eq 1 ]]; then
+  autogenForFile "${FILE}" | prependToFileInPlace "${FILE}"
+  exit $?
+else
+  autogenForFile "${FILE}"
+fi


### PR DESCRIPTION
This was done because the script only generated the final output to `stdout`
with no way to capture it to redirect into a file. It also made it hard to add
any additional functionality without breaking the inline modification because we
had to do a bidirectional conversion of flags -> variables and then variables ->
flags for the re-execution of `autogen`.

This change encloses the entire output in a function, such that it's easy to
call either to output to `stdout` or to capture the output and prepend to a
file.