### PR TITLE
Minor indentation and whitespace cleanups

### DIFF
--- a/autogen
+++ b/autogen
@@ -397,8 +397,8 @@ function autogenForFile() {
       fi
       printLicenseHashComment
       printFileCommentTemplate "#"
-      echo
       if [ ${ADD_CODE} -eq 1 ]; then
+        echo
         echo "use strict;"
       fi
       ;;
@@ -425,7 +425,7 @@ EOF
           echo "import ${BASE_PY/%.py/}"
         fi
         # Add basic bootstrap code.
-      cat <<EOF
+        cat <<EOF
 
 
 class FooTest(unittest.TestCase):
@@ -460,7 +460,7 @@ EOF
 EOF
       fi
       if [ ${ADD_CODE} -eq 1 ]; then
-      cat <<EOF
+        cat <<EOF
 import sys
 
 

--- a/tests/testdata/bsd2-acme-pl-no-code-no-runline.out
+++ b/tests/testdata/bsd2-acme-pl-no-code-no-runline.out
@@ -27,4 +27,3 @@
 
 # TODO: High-level file comment.
 
-


### PR DESCRIPTION
Fixed indentation in a few places and put the `echo` before Perl codegen into
the `if` statement to avoid a double-blank line after the top-level comment.

This addresses the post-merge comments I left on PR #48.
/cc: @gennadiycivil 