### PR TITLE
Mark macOS builds optional and allowed to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,3 +97,8 @@ matrix:
         - brew install bazel
       script:
         - bazel test //...
+
+  allow_failures:
+    - os: osx
+
+  fast_finish: true


### PR DESCRIPTION
macOS builds take longer and longer to start, holding up the build. Cancelling
them via the Travis CI web UI marks the build as having failed.

Here, we combine the following two features:

* https://docs.travis-ci.com/user/multi-os/#Allowing-Failures-on-Jobs-Running-on-One-Operating-System
* https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/

to make the macOS builds optional, as well as make the build succeed as soon as
the fast build/test cycle (Linux) succeeds. If we are lucky, we will get OS X
tested; however, we are not going to be able to wait for it.