### PR TITLE
Build only `master` branch with Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@
 language: generic
 sudo: false
 
+branches:
+  only:
+    - master
+
 matrix:
   include:
     - os: linux


### PR DESCRIPTION
Avoid wasting extra cycles on additional short-lived branches created in this repo simply for opening PRs.