### PR TITLE
Use Xcode 9.3 on macOS to get JDK 1.8 for Bazel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,11 @@ matrix:
         - make regen-test
 
     - os: osx
+      # We need JDK 1.8 because that's what Bazel installer in Homebrew
+      # currently requires, and the default version of Xcode installs JDK 10.x
+      # which does not satisfy the dependency requirement.
+      osx_image: xcode9.3
+      language: java
       env: TEST_RUNNER=bazel
       sudo: false
       before_install:


### PR DESCRIPTION
Installing Bazel via Homebrew requires JDK 1.8; the default on macOS on
Travis CI is Xcode 9.4, which installs JDK 10.0.1+10 which is the wrong
dependency for Bazel.

Pre https://docs.travis-ci.com/user/reference/osx/ we need to specify
`osx_image: xcode9.3` to get the latest JDK 1.8.0_112-b16, which should
satisfy the Bazel requirement.