### PR TITLE
Add missing dependency from autogen to ipynb.py

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,4 +19,7 @@ package(default_visibility = ["//visibility:public"])
 sh_binary(
     name = "autogen_tool",
     srcs = ["autogen"],
+    data = [
+        "ipynb.py",
+    ],
 )


### PR DESCRIPTION
Fixes the Bazel build (added in PR #66); make already worked.