### PR TITLE
Fix Bazel install on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,7 @@ matrix:
       before_install:
         - brew update
         - brew tap bazelbuild/tap
-        - brew tap-pin bazelbuild/tap
-        - brew install bazel
+        - brew install bazelbuild/tap/bazel
       script:
         - bazel test //...
 


### PR DESCRIPTION
Using the newest instructions from:
https://docs.bazel.build/versions/2.0.0/install-os-x.html#step-2-install-the-bazel-homebrew-package

Fixes #71