### PR TITLE
Remove `regen-test` from Makefile and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ jobs:
       env: TEST_RUNNER=make VERBOSE=1
       script:
         - make test
-        - make regen-test
 
     - os: linux
       dist: bionic
@@ -49,7 +48,6 @@ jobs:
       env: TEST_RUNNER=make VERBOSE=1
       script:
         - make test
-        - make regen-test
 
     - os: osx
       language: java

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,3 @@ test:
 
 regen:
 	$(VERB) bash gen_test_results.sh
-
-regen-test:
-	$(VERB) $(MAKE) regen
-	$(VERB) $(MAKE) test


### PR DESCRIPTION
We don't really need this test, since it will be generated and then validated
with the same `autogen` script: it should always pass.

This would only be useful in the course of local development when updating the
autogen tool itself, e.g., adding support for new filetypes or changing the
behavior of a flag.