### PR TITLE
Speed up Travis on macOS by avoiding implicit `brew update` before `brew install bazel`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ jobs:
         - make test
 
     - os: osx
+      osx_image: xcode9.3
       language: java
       env: TEST_RUNNER=bazel
       before_cache:
@@ -59,8 +60,9 @@ jobs:
           - $HOME/Library/Caches/Homebrew
       # Bazel installation instructions as per
       # https://docs.bazel.build/versions/master/install-os-x.html#install-on-mac-os-x-homebrew
+      # The env var prevents automatic `brew update` before `brew install`.
       install:
-        - brew install bazel
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install bazel
       script:
         - bazel test //...
 


### PR DESCRIPTION
Bazel ships with its own embedded JRE, so unless you need to compile Java source
files, you don't need the full JDK. Homebrew, however, insists on installing
Ruby before continuing (since Homebrew recipes are all Ruby scripts), so by
starting with a Ruby image, we should cut down on that step and save some time.

Also added an explicit `brew update` step since Homebrew insists on calling it
every time when we're installing Bazel; hopefully, this will get it to cache the
metadata across builds as well.