### PR TITLE
Update all GitHub Actions to newer versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Bazelisk
-        uses: bazelbuild/setup-bazelisk@v1
+        uses: bazelbuild/setup-bazelisk@v3
 
       - name: Setup cache for Bazel
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: "~/.cache/bazel"
           key: bazel


### PR DESCRIPTION
* actions/checkout: v2 -> v4
* bazelbuild/setup-bazelisk: v1 -> v3
* actions/cache: v2 -> v4